### PR TITLE
Use gRPC

### DIFF
--- a/nodejs/packages/layer/package.json
+++ b/nodejs/packages/layer/package.json
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "^0.34.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "^0.34.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.34.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.34.0",
     "@opentelemetry/instrumentation": "^0.34.0",
     "@coralogix/instrumentation-aws-lambda": "0.34.2-SNAPSHOT",
     "@opentelemetry/instrumentation-aws-sdk": "^0.10.0",

--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -37,7 +37,7 @@ const { MySQLInstrumentation } = require('@opentelemetry/instrumentation-mysql')
 const { NetInstrumentation } = require('@opentelemetry/instrumentation-net');
 const { PgInstrumentation } = require('@opentelemetry/instrumentation-pg');
 const { RedisInstrumentation } = require('@opentelemetry/instrumentation-redis');
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 
 declare global {
   // in case of downstream configuring span processors etc

--- a/nodejs/sample-apps/aws-sdk/deploy/wrapper/main.tf
+++ b/nodejs/sample-apps/aws-sdk/deploy/wrapper/main.tf
@@ -21,7 +21,7 @@ module "hello-lambda-function" {
   environment_variables = {
     AWS_LAMBDA_EXEC_WRAPPER     = "/opt/otel-handler"
     OTEL_LOG_LEVEL              = "DEBUG"
-    OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4318/"
+    OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317/"
     OPENTELEMETRY_COLLECTOR_CONFIG_FILE= "/var/task/config.yaml"
   }
 


### PR DESCRIPTION
The telemetry-exporter supports only gRPC.
As far as I can see, we run the opentelemetry-collector with both http and grpc enabled anyway, so this should work in both cases.