### PR TITLE
Correct response payload attribute name and adjust default limit

### DIFF
--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -83,7 +83,7 @@ const OtelAttributes = {
   DB_RESPONSE: 'db.response',
 };
 
-const DEFAULT_OTEL_PAYLOAD_SIZE_LIMIT = 200;
+const DEFAULT_OTEL_PAYLOAD_SIZE_LIMIT = 50 * 1024;
 
 const parseIntEnvvar = (envName: string): number | undefined => {
   const envVar = process.env?.[envName];

--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -79,7 +79,7 @@ declare global {
 
 const OtelAttributes = {
   RPC_REQUEST_PAYLOAD: 'rpc.request.payload',
-  RPC_RESPONSE_PAYLOAD: 'rpc.request.payload',
+  RPC_RESPONSE_PAYLOAD: 'rpc.response.payload',
   DB_RESPONSE: 'db.response',
 };
 


### PR DESCRIPTION
Reference for the 50kiB default:
https://coralogix-dev.slack.com/archives/C056NF8RS22/p1685007918632419

@povilasv will align Python autoinstrumetnation to the same default.