### PR TITLE
NGSTN-726 modules / sst support

### DIFF
--- a/.github/workflows/publish-nodejs.yml
+++ b/.github/workflows/publish-nodejs.yml
@@ -38,7 +38,7 @@ jobs:
         path: ${{ env.IITM_PATH }}
         repository: coralogix/import-in-the-middle
         ref: refs/heads/coralogix-autoinstrumentation
-        ssh-key: ${{ secrets.OPENTELEMETRY_CI_GITHUB_KEY }}
+        ssh-key: ${{ secrets.OPENTELEMETRY_CI_IITM_GITHUB_KEY }}
     - name: Build
       run: ./ci-scripts/build_nodejs_layer.hs
     - name: Check layer size

--- a/.github/workflows/publish-nodejs.yml
+++ b/.github/workflows/publish-nodejs.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       OPENTELEMETRY_JS_CONTRIB_PATH: ${{ github.workspace }}/opentelemetry-js-contrib
       OPENTELEMETRY_JS_PATH: ${{ github.workspace }}/opentelemetry-js
+      IITM_PATH: ${{ github.workspace }}/import-in-the-middle
     steps:
     - uses: actions/checkout@v3
     - uses: actions/checkout@v3
@@ -32,56 +33,14 @@ jobs:
         repository: coralogix/opentelemetry-js
         ref: refs/heads/coralogix-autoinstrumentation
         ssh-key: ${{ secrets.OPENTELEMETRY_CI_GITHUB_KEY }}
-    - name: Generate version files in opentelemetry-js-contrib
-      working-directory: ${{ env.OPENTELEMETRY_JS_CONTRIB_PATH }}
-      run: npx lerna@6.6.2 run version:update # Newer versions have trouble with our lerna.json which contains `useWorkspaces`
-    - name: Prepare opentelemetry-js-contrib
-      working-directory: ${{ env.OPENTELEMETRY_JS_CONTRIB_PATH }}
-      run: npm install
-    - name: Build opentelemetry-test-utils
-      working-directory: ${{ env.OPENTELEMETRY_JS_CONTRIB_PATH }}/packages/opentelemetry-test-utils
-      run: npm install && npm run compile
-    - name: Build opentelemetry-propagator-aws-xray
-      working-directory: ${{ env.OPENTELEMETRY_JS_CONTRIB_PATH }}/propagators/opentelemetry-propagator-aws-xray
-      run: npm install && npm run compile
-    - name: Build opentelemetry-propagation-utils
-      working-directory: ${{ env.OPENTELEMETRY_JS_CONTRIB_PATH }}/packages/opentelemetry-propagation-utils
-      run: npm install && npm run compile
-    - name: Build opentelemetry-instrumentation-aws-lambda
-      working-directory: ${{ env.OPENTELEMETRY_JS_CONTRIB_PATH }}/plugins/node/opentelemetry-instrumentation-aws-lambda
-      run: npm install --ignore-scripts && npm run compile && npm pack --ignore-scripts
-    - name: Build opentelemetry-instrumentation-mongodb
-      working-directory: ${{ env.OPENTELEMETRY_JS_CONTRIB_PATH }}/plugins/node/opentelemetry-instrumentation-mongodb
-      run: npm install --ignore-scripts && npm run compile && npm pack --ignore-scripts
-    - name: Build opentelemetry-instrumentation-aws-sdk
-      working-directory: ${{ env.OPENTELEMETRY_JS_CONTRIB_PATH }}/plugins/node/opentelemetry-instrumentation-aws-sdk
-      run: npm install --ignore-scripts && npm run compile && npm pack --ignore-scripts
-    - name: Prepare opentelemetry-js
-      working-directory: ${{ env.OPENTELEMETRY_JS_PATH }}
-      run: npm install
-    - name: Build sdk-logs
-      working-directory: ${{ env.OPENTELEMETRY_JS_PATH }}/experimental/packages/sdk-logs
-      run: npm install && npm run compile
-    - name: Build opentelemetry-instrumentation
-      working-directory: ${{ env.OPENTELEMETRY_JS_PATH }}/experimental/packages/opentelemetry-instrumentation
-      run: npm install && npm run compile && npm pack
-    - name: Build opentelemetry-sdk-trace-base
-      working-directory: ${{ env.OPENTELEMETRY_JS_PATH }}/packages/opentelemetry-sdk-trace-base
-      run: npm install && npm run compile && npm pack
-    - name: Install forked opentelemetry-js/opentelemetry-js-contrib libraries
-      working-directory: ./nodejs/packages/layer
-      run: >
-        npm install 
-        ${OPENTELEMETRY_JS_CONTRIB_PATH}/plugins/node/opentelemetry-instrumentation-aws-lambda/opentelemetry-instrumentation-aws-lambda-*.tgz
-        ${OPENTELEMETRY_JS_CONTRIB_PATH}/plugins/node/opentelemetry-instrumentation-mongodb/opentelemetry-instrumentation-mongodb-*.tgz
-        ${OPENTELEMETRY_JS_CONTRIB_PATH}/plugins/node/opentelemetry-instrumentation-aws-sdk/opentelemetry-instrumentation-aws-sdk-*.tgz
-        ${OPENTELEMETRY_JS_PATH}/experimental/packages/opentelemetry-instrumentation/opentelemetry-instrumentation-*.tgz
-        ${OPENTELEMETRY_JS_PATH}/packages/opentelemetry-sdk-trace-base/opentelemetry-sdk-trace-base-*.tgz
-    - name: Install copyfiles and bestzip # used by `npm run compile`
-      run: npm install -g copyfiles bestzip
-    - name: Build layer
-      working-directory: ./nodejs/packages/layer
-      run: npm install && npm run compile
+    - uses: actions/checkout@v3
+      with:
+        path: ${{ env.IITM_PATH }}
+        repository: coralogix/import-in-the-middle
+        ref: refs/heads/coralogix-autoinstrumentation
+        ssh-key: ${{ secrets.OPENTELEMETRY_CI_GITHUB_KEY }}
+    - name: Build
+      run: ./ci-scripts/build_nodejs_layer.hs
     - name: Check layer size
       env:
         FILE_PATH: ./nodejs/packages/layer/build/layer.zip

--- a/.github/workflows/publish-nodejs.yml
+++ b/.github/workflows/publish-nodejs.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         path: ${{ env.OPENTELEMETRY_JS_CONTRIB_PATH }}
         repository: coralogix/opentelemetry-js-contrib
-        ref: refs/heads/feature/NGSTN-726-sst-support
+        ref: refs/heads/coralogix-autoinstrumentation
         ssh-key: ${{ secrets.OPENTELEMETRY_CI_GITHUB_KEY }}
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/publish-nodejs.yml
+++ b/.github/workflows/publish-nodejs.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         path: ${{ env.OPENTELEMETRY_JS_CONTRIB_PATH }}
         repository: coralogix/opentelemetry-js-contrib
-        ref: refs/heads/coralogix-autoinstrumentation
+        ref: refs/heads/feature/NGSTN-726-sst-support
         ssh-key: ${{ secrets.OPENTELEMETRY_CI_GITHUB_KEY }}
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/publish-nodejs.yml
+++ b/.github/workflows/publish-nodejs.yml
@@ -40,7 +40,7 @@ jobs:
         ref: refs/heads/coralogix-autoinstrumentation
         ssh-key: ${{ secrets.OPENTELEMETRY_CI_IITM_GITHUB_KEY }}
     - name: Build
-      run: ./ci-scripts/build_nodejs_layer.hs
+      run: ./ci-scripts/build_nodejs_layer.sh
     - name: Check layer size
       env:
         FILE_PATH: ./nodejs/packages/layer/build/layer.zip

--- a/ci-scripts/build_nodejs_layer.sh
+++ b/ci-scripts/build_nodejs_layer.sh
@@ -98,7 +98,7 @@ npm install \
     ${OPENTELEMETRY_JS_CONTRIB_PATH}/plugins/node/opentelemetry-instrumentation-aws-sdk/opentelemetry-instrumentation-aws-sdk-*.tgz \
     ${OPENTELEMETRY_JS_PATH}/experimental/packages/opentelemetry-instrumentation/opentelemetry-instrumentation-*.tgz \
     ${OPENTELEMETRY_JS_PATH}/packages/opentelemetry-sdk-trace-base/opentelemetry-sdk-trace-base-*.tgz \
-    ${IITM_PATH}/import-in-the-middle-*.tgz \
+    ${IITM_PATH}/import-in-the-middle-*.tgz
 popd > /dev/null
 
 # Install copyfiles and bestzip # used by `npm run compile`

--- a/ci-scripts/build_nodejs_layer.sh
+++ b/ci-scripts/build_nodejs_layer.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ -z "${OPENTELEMETRY_JS_CONTRIB_PATH:-}" ]; then
+    echo "OPENTELEMETRY_JS_CONTRIB_PATH is not set"
+    exit 1
+fi
+OPENTELEMETRY_JS_CONTRIB_PATH=$(realpath $OPENTELEMETRY_JS_CONTRIB_PATH)
+
+if [ -z "${OPENTELEMETRY_JS_PATH:-}" ]; then
+    echo "OPENTELEMETRY_JS_PATH is not set"
+    exit 1
+fi
+
+OPENTELEMETRY_JS_PATH=$(realpath $OPENTELEMETRY_JS_PATH)
+
+if [ -z "${IITM_PATH:-}" ]; then
+    echo "IITM_PATH is not set"
+    exit 1
+fi
+
+IITM_PATH=$(realpath $IITM_PATH)
+
+pushd $OPENTELEMETRY_JS_CONTRIB_PATH > /dev/null
+# Generate version files in opentelemetry-js-contrib
+npx lerna@6.6.2 run version:update # Newer versions have trouble with our lerna.json which contains `useWorkspaces`
+# Prepare opentelemetry-js-contrib
+npm install
+popd > /dev/null
+
+# Build opentelemetry-test-utils
+pushd $OPENTELEMETRY_JS_CONTRIB_PATH/packages/opentelemetry-test-utils
+npm install && npm run compile
+popd > /dev/null
+
+# Build opentelemetry-propagator-aws-xray
+pushd $OPENTELEMETRY_JS_CONTRIB_PATH/propagators/opentelemetry-propagator-aws-xray
+npm install && npm run compile
+popd > /dev/null
+
+# Build opentelemetry-propagation-utils
+pushd $OPENTELEMETRY_JS_CONTRIB_PATH/packages/opentelemetry-propagation-utils
+npm install && npm run compile
+popd > /dev/null
+
+# Build opentelemetry-instrumentation-aws-lambda
+pushd $OPENTELEMETRY_JS_CONTRIB_PATH/plugins/node/opentelemetry-instrumentation-aws-lambda
+rm -f opentelemetry-instrumentation-aws-lambda-*.tgz
+npm install --ignore-scripts && npm run compile && npm pack --ignore-scripts
+popd > /dev/null
+
+# Build opentelemetry-instrumentation-mongodb
+pushd $OPENTELEMETRY_JS_CONTRIB_PATH/plugins/node/opentelemetry-instrumentation-mongodb
+rm -f opentelemetry-instrumentation-mongodb-*.tgz
+npm install --ignore-scripts && npm run compile && npm pack --ignore-scripts
+popd > /dev/null
+
+# Build opentelemetry-instrumentation-aws-sdk
+pushd $OPENTELEMETRY_JS_CONTRIB_PATH/plugins/node/opentelemetry-instrumentation-aws-sdk
+rm -f opentelemetry-instrumentation-aws-sdk-*.tgz
+npm install --ignore-scripts && npm run compile && npm pack --ignore-scripts
+popd > /dev/null
+
+# Prepare opentelemetry-js
+pushd $OPENTELEMETRY_JS_PATH
+npm install
+popd > /dev/null
+
+# Build sdk-logs
+pushd $OPENTELEMETRY_JS_PATH/experimental/packages/sdk-logs
+npm install && npm run compile
+popd > /dev/null
+
+# Build opentelemetry-instrumentation
+pushd $OPENTELEMETRY_JS_PATH/experimental/packages/opentelemetry-instrumentation
+rm -f opentelemetry-instrumentation-*.tgz
+npm install && npm run compile && npm pack
+popd > /dev/null
+
+# Build opentelemetry-sdk-trace-base
+pushd $OPENTELEMETRY_JS_PATH/packages/opentelemetry-sdk-trace-base
+rm -f opentelemetry-sdk-trace-base-*.tgz
+npm install && npm run compile && npm pack
+popd > /dev/null
+
+# Build import-in-the-middle
+pushd $IITM_PATH
+rm -f import-in-the-middle-*.tgz
+npm install && npm pack
+popd > /dev/null
+
+# Install forked opentelemetry-js/opentelemetry-js-contrib libraries
+pushd ./nodejs/packages/layer
+npm install \
+    ${OPENTELEMETRY_JS_CONTRIB_PATH}/plugins/node/opentelemetry-instrumentation-aws-lambda/opentelemetry-instrumentation-aws-lambda-*.tgz \
+    ${OPENTELEMETRY_JS_CONTRIB_PATH}/plugins/node/opentelemetry-instrumentation-mongodb/opentelemetry-instrumentation-mongodb-*.tgz \
+    ${OPENTELEMETRY_JS_CONTRIB_PATH}/plugins/node/opentelemetry-instrumentation-aws-sdk/opentelemetry-instrumentation-aws-sdk-*.tgz \
+    ${OPENTELEMETRY_JS_PATH}/experimental/packages/opentelemetry-instrumentation/opentelemetry-instrumentation-*.tgz \
+    ${OPENTELEMETRY_JS_PATH}/packages/opentelemetry-sdk-trace-base/opentelemetry-sdk-trace-base-*.tgz \
+    ${IITM_PATH}/import-in-the-middle-*.tgz \
+popd > /dev/null
+
+# Install copyfiles and bestzip # used by `npm run compile`
+npm install -g copyfiles bestzip
+
+# Build layer
+pushd ./nodejs/packages/layer
+npm install && npm run compile
+popd > /dev/null

--- a/nodejs/packages/layer/package-lock.json
+++ b/nodejs/packages/layer/package-lock.json
@@ -34,7 +34,8 @@
         "@opentelemetry/resources": "1.22.0",
         "@opentelemetry/sdk-metrics": "1.22.0",
         "@opentelemetry/sdk-trace-base": "file:../../../../../oss/opentelemetry-js/packages/opentelemetry-sdk-trace-base/opentelemetry-sdk-trace-base-1.22.0.tgz",
-        "@opentelemetry/sdk-trace-node": "1.22.0"
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "import-in-the-middle": "file:../../../../import-in-the-middle/import-in-the-middle-1.7.3.tgz"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -266,7 +267,7 @@
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.49.1",
       "resolved": "file:../../../../../oss/opentelemetry-js/experimental/packages/opentelemetry-instrumentation/opentelemetry-instrumentation-0.49.1.tgz",
-      "integrity": "sha512-lO+vUdwvGgFrH8FPJTEhX8R9pDm72DUVITdvPG5QV4Kir43pG8jrtOSn4CKhsrqwFl/LRrCoR9QG0orimxU1gg==",
+      "integrity": "sha512-0sjClb7PniT8DiKLnYcIFIQ5xoL52/hKjch3adjSnwRYk5b4yA3N3R/YDkRwG+20xrMOPlt3xsiozCOmH6b6MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.49.1",
@@ -286,7 +287,7 @@
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
       "version": "0.39.0",
       "resolved": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-lambda/opentelemetry-instrumentation-aws-lambda-0.39.0.tgz",
-      "integrity": "sha512-QsNHuEzhsJLI2675S8YAqWOoabcQ8jgGCp2pD4soWhER43R5BMQwBxO389XZ2LSQ189eu8GvnUJsO1PVCr9Vew==",
+      "integrity": "sha512-/+glrrwGWkuAAVhF8cn1Qn/7Oa+yqmb8ORNAN2heXS4bSdkWkhalwsmRI9dnnqmwZac9UG7asWTxHgEikgNwAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.49.1",
@@ -1199,9 +1200,10 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+      "version": "1.7.3",
+      "resolved": "file:../../../../import-in-the-middle/import-in-the-middle-1.7.3.tgz",
+      "integrity": "sha512-uJ8/jDqguc7iiS2I8cdu9vRcJ3YeSPMnQA/JX9SOGjcIisuOk+BauDsI4YZS8B7MNvSM4rLErsaxK8JIfL+u8A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.8.2",
         "acorn-import-assertions": "^1.9.0",

--- a/nodejs/packages/layer/package-lock.json
+++ b/nodejs/packages/layer/package-lock.json
@@ -14,8 +14,8 @@
         "@opentelemetry/exporter-metrics-otlp-grpc": "0.49.1",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
         "@opentelemetry/instrumentation": "file:../../../../../oss/opentelemetry-js/experimental/packages/opentelemetry-instrumentation/opentelemetry-instrumentation-0.49.1.tgz",
-        "@opentelemetry/instrumentation-aws-lambda": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-lambda/coralogix-instrumentation-aws-lambda-0.39.0.tgz",
-        "@opentelemetry/instrumentation-aws-sdk": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-sdk/coralogix-instrumentation-aws-sdk-0.39.0.tgz",
+        "@opentelemetry/instrumentation-aws-lambda": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-lambda/opentelemetry-instrumentation-aws-lambda-0.39.0.tgz",
+        "@opentelemetry/instrumentation-aws-sdk": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-sdk/opentelemetry-instrumentation-aws-sdk-0.39.0.tgz",
         "@opentelemetry/instrumentation-dns": "^0.34.0",
         "@opentelemetry/instrumentation-express": "^0.36.1",
         "@opentelemetry/instrumentation-graphql": "^0.38.1",
@@ -266,7 +266,7 @@
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.49.1",
       "resolved": "file:../../../../../oss/opentelemetry-js/experimental/packages/opentelemetry-instrumentation/opentelemetry-instrumentation-0.49.1.tgz",
-      "integrity": "sha512-clb1h9dhzB6JecUTthUoe+/lWwK7ZHgka+ifRWDf6mFSbxSwHcLs2f3GKhwB78D8RiZbFMoxbJ7LFr3fOBbOHQ==",
+      "integrity": "sha512-lO+vUdwvGgFrH8FPJTEhX8R9pDm72DUVITdvPG5QV4Kir43pG8jrtOSn4CKhsrqwFl/LRrCoR9QG0orimxU1gg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.49.1",
@@ -284,10 +284,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "name": "@coralogix/instrumentation-aws-lambda",
       "version": "0.39.0",
-      "resolved": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-lambda/coralogix-instrumentation-aws-lambda-0.39.0.tgz",
-      "integrity": "sha512-VfixUZzKc0Sr7sYVNsyH4mbHcybbxKSlOrLmnQqfGgnQYzyITagJ8Jgs8Dh/J0vsw+7mTDWAIUMnLfXF5GWvOw==",
+      "resolved": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-lambda/opentelemetry-instrumentation-aws-lambda-0.39.0.tgz",
+      "integrity": "sha512-QsNHuEzhsJLI2675S8YAqWOoabcQ8jgGCp2pD4soWhER43R5BMQwBxO389XZ2LSQ189eu8GvnUJsO1PVCr9Vew==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.49.1",
@@ -303,16 +302,10 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-aws-lambda/node_modules/@types/aws-lambda": {
-      "version": "8.10.122",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.122.tgz",
-      "integrity": "sha512-vBkIh9AY22kVOCEKo5CJlyCgmSWvasC+SWUxL/x/vOwRobMpI/HG1xp/Ae3AqmSiZeLUbOhW0FCD3ZjqqUxmXw=="
-    },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
-      "name": "@coralogix/instrumentation-aws-sdk",
       "version": "0.39.0",
-      "resolved": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-sdk/coralogix-instrumentation-aws-sdk-0.39.0.tgz",
-      "integrity": "sha512-mQk/GL6jzgNPbYJmp4syuAzsXNJoKTP8Lan/iVtJsEgXRrwXAGPK2KBMGBsle2Ghn6ReuPpNyKy6OwsIxTlaCA==",
+      "resolved": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-sdk/opentelemetry-instrumentation-aws-sdk-0.39.0.tgz",
+      "integrity": "sha512-bt3+iFdjwPi6FhC5oMHWhh+cvI4GMVF2ZeaY7AbpleX5LU+gn0aYwKM6S1QitMlntwjuxh3eTbl0xzjLUmfmag==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
@@ -460,7 +453,7 @@
     "node_modules/@opentelemetry/instrumentation-mongodb": {
       "version": "0.40.0",
       "resolved": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-mongodb/opentelemetry-instrumentation-mongodb-0.40.0.tgz",
-      "integrity": "sha512-Xs5KDFkK7rvvY/u6zwIZEAH82sJJ83t0SpeidjdXszzRmdwImSd5AVFLbIe9HG/u0UmQsPXW/XCn9Vi5XF9wnQ==",
+      "integrity": "sha512-0VI2Y3izUYPe3HsUfgPXFciR9n6CcuTL/xLPCPjeGg1Zg/fxg5FN/BH9gqhylpxymFoHBRn1OvWlpX9w0Wabyw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.49.1",
@@ -850,6 +843,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.122",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.122.tgz",
+      "integrity": "sha512-vBkIh9AY22kVOCEKo5CJlyCgmSWvasC+SWUxL/x/vOwRobMpI/HG1xp/Ae3AqmSiZeLUbOhW0FCD3ZjqqUxmXw=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",

--- a/nodejs/packages/layer/package.json
+++ b/nodejs/packages/layer/package.json
@@ -26,13 +26,13 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
     "@opentelemetry/api": "^1.7.0",
+    "@opentelemetry/core": "1.22.0",
     "@opentelemetry/exporter-metrics-otlp-grpc": "0.49.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
     "@opentelemetry/instrumentation": "file:../../../../../oss/opentelemetry-js/experimental/packages/opentelemetry-instrumentation/opentelemetry-instrumentation-0.49.1.tgz",
-    "@opentelemetry/instrumentation-aws-lambda": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-lambda/coralogix-instrumentation-aws-lambda-0.39.0.tgz",
-    "@opentelemetry/instrumentation-aws-sdk": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-sdk/coralogix-instrumentation-aws-sdk-0.39.0.tgz",
+    "@opentelemetry/instrumentation-aws-lambda": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-lambda/opentelemetry-instrumentation-aws-lambda-0.39.0.tgz",
+    "@opentelemetry/instrumentation-aws-sdk": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-sdk/opentelemetry-instrumentation-aws-sdk-0.39.0.tgz",
     "@opentelemetry/instrumentation-dns": "^0.34.0",
     "@opentelemetry/instrumentation-express": "^0.36.1",
     "@opentelemetry/instrumentation-graphql": "^0.38.1",

--- a/nodejs/packages/layer/package.json
+++ b/nodejs/packages/layer/package.json
@@ -51,6 +51,12 @@
     "@opentelemetry/resources": "1.22.0",
     "@opentelemetry/sdk-metrics": "1.22.0",
     "@opentelemetry/sdk-trace-base": "file:../../../../../oss/opentelemetry-js/packages/opentelemetry-sdk-trace-base/opentelemetry-sdk-trace-base-1.22.0.tgz",
-    "@opentelemetry/sdk-trace-node": "1.22.0"
+    "@opentelemetry/sdk-trace-node": "1.22.0",
+    "import-in-the-middle": "file:../../../../import-in-the-middle/import-in-the-middle-1.7.3.tgz"
+  },
+  "overrides": {
+    "@opentelemetry/instrumentation": {
+      "import-in-the-middle": "$import-in-the-middle"
+    }
   }
 }

--- a/nodejs/packages/layer/scripts/otel-handler
+++ b/nodejs/packages/layer/scripts/otel-handler
@@ -1,8 +1,10 @@
 #!/bin/bash
-MJS_FILE="${LAMBDA_TASK_ROOT}/${_HANDLER%.*}.mjs"
 
-# If it's an mjs file, then we enable the hook for node modules loading
-if [ -f "${DIR_PATH}" ]; then
+echo "LAMBDA_TASK_ROOT=${LAMBDA_TASK_ROOT}"
+echo "_HANDLER=${_HANDLER}"
+
+# If the handler is in an .mjs file we need to use a loader hook. We can't detect it here because the corresponding env vars are not available at this point
+if [ "$OTEL_NODEJS_HOOK" == "modules" ]; then
     export NODE_OPTIONS="${NODE_OPTIONS} --experimental-loader=@opentelemetry/instrumentation/hook.mjs"
     # Disable node warnings caused by --experimental-loader
     export NODE_NO_WARNINGS=1

--- a/nodejs/packages/layer/scripts/otel-handler
+++ b/nodejs/packages/layer/scripts/otel-handler
@@ -3,8 +3,9 @@ MJS_FILE="${LAMBDA_TASK_ROOT}/${_HANDLER%.*}.mjs"
 
 # If it's an mjs file, then we enable the hook for node modules loading
 if [ -f "${DIR_PATH}" ]; then
-    # If the file exists, export NODE_OPTIONS
     export NODE_OPTIONS="${NODE_OPTIONS} --experimental-loader=@opentelemetry/instrumentation/hook.mjs"
+    # Disable node warnings caused by --experimental-loader
+    export NODE_NO_WARNINGS=1
 fi
 
 export NODE_OPTIONS="${NODE_OPTIONS} --require /opt/wrapper.js"

--- a/nodejs/packages/layer/scripts/otel-handler
+++ b/nodejs/packages/layer/scripts/otel-handler
@@ -1,4 +1,11 @@
 #!/bin/bash
+MJS_FILE="${LAMBDA_TASK_ROOT}/${_HANDLER%.*}.mjs"
+
+# If it's an mjs file, then we enable the hook for node modules loading
+if [ -f "${DIR_PATH}" ]; then
+    # If the file exists, export NODE_OPTIONS
+    export NODE_OPTIONS="${NODE_OPTIONS} --experimental-loader=@opentelemetry/instrumentation/hook.mjs"
+fi
 
 export NODE_OPTIONS="${NODE_OPTIONS} --require /opt/wrapper.js"
 

--- a/nodejs/packages/layer/scripts/otel-handler
+++ b/nodejs/packages/layer/scripts/otel-handler
@@ -1,10 +1,6 @@
 #!/bin/bash
 
-echo "LAMBDA_TASK_ROOT=${LAMBDA_TASK_ROOT}"
-echo "_HANDLER=${_HANDLER}"
-
 possible_mjs_handler_file="${LAMBDA_TASK_ROOT}/${_HANDLER%.*}.mjs"
-echo "possible_mjs_handler_file=${possible_mjs_handler_file}"
 
 # If the handler is in an .mjs file we need to use a loader hook. We can't detect it here because the corresponding env vars are not available at this point
 if [ "$OTEL_NODEJS_HOOK" == "modules" ] || [ -f "$possible_mjs_handler_file" ]; then

--- a/nodejs/packages/layer/scripts/otel-handler
+++ b/nodejs/packages/layer/scripts/otel-handler
@@ -3,8 +3,11 @@
 echo "LAMBDA_TASK_ROOT=${LAMBDA_TASK_ROOT}"
 echo "_HANDLER=${_HANDLER}"
 
+possible_mjs_handler_file="${LAMBDA_TASK_ROOT}/${_HANDLER%.*}.mjs"
+echo "possible_mjs_handler_file=${possible_mjs_handler_file}"
+
 # If the handler is in an .mjs file we need to use a loader hook. We can't detect it here because the corresponding env vars are not available at this point
-if [ "$OTEL_NODEJS_HOOK" == "modules" ]; then
+if [ "$OTEL_NODEJS_HOOK" == "modules" ] || [ -f "$possible_mjs_handler_file" ]; then
     export NODE_OPTIONS="${NODE_OPTIONS} --experimental-loader=@opentelemetry/instrumentation/hook.mjs"
     # Disable node warnings caused by --experimental-loader
     export NODE_NO_WARNINGS=1

--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -1,3 +1,7 @@
+import { register } from "node:module"; 
+import { pathToFileURL } from "node:url"; 
+register("@opentelemetry/instrumentation/hook.mjs", pathToFileURL("./"));
+
 import {
   NodeTracerConfig,
   NodeTracerProvider,
@@ -37,6 +41,9 @@ import { PgResponseHookInformation } from '@opentelemetry/instrumentation-pg';
 
 import { MeterProvider, MeterProviderOptions, PeriodicExportingMetricReader, AggregationTemporality } from '@opentelemetry/sdk-metrics';
 
+// configure lambda logging
+const logLevel = getEnv().OTEL_LOG_LEVEL;
+diag.setLogger(new DiagConsoleLogger(), logLevel);
 
 function defaultConfigureInstrumentations() {
   // Use require statements for instrumentation to avoid having to have transitive dependencies on all the typescript
@@ -235,10 +242,6 @@ const instrumentations = [
   new AwsLambdaInstrumentation(typeof configureLambdaInstrumentation === 'function' ? configureLambdaInstrumentation(lambdaAutoInstrumentConfig) : lambdaAutoInstrumentConfig),
   ...(typeof configureInstrumentations === 'function' ? configureInstrumentations: defaultConfigureInstrumentations)()
 ];
-
-// configure lambda logging
-const logLevel = getEnv().OTEL_LOG_LEVEL;
-diag.setLogger(new DiagConsoleLogger(), logLevel);
 
 // Register instrumentations synchronously to ensure code is patched even before provider is ready.
 registerInstrumentations({

--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -1,7 +1,3 @@
-import { register } from "node:module"; 
-import { pathToFileURL } from "node:url"; 
-register("@opentelemetry/instrumentation/hook.mjs", pathToFileURL("./"));
-
 import {
   NodeTracerConfig,
   NodeTracerProvider,


### PR DESCRIPTION
* Automatically add import-in-the-middle hook when the handler is in an .mjs file (also make it possible to fore this via an env var)
* use forked import-in-the-middle
* move the process of building the layer from `yaml` to `sh`, for easier local use