### PR TITLE
Disable callbackWaitsForEmptyEventLoop for promise based handlers

### DIFF
--- a/nodejs/packages/cx-wrapper/index.ts
+++ b/nodejs/packages/cx-wrapper/index.ts
@@ -36,22 +36,35 @@ export const handler = (event: any, context: Context, callback: Callback) => {
     process.env.CX_ORIGINAL_HANDLER
   ).then(
     (originalHandler) => {
-      diag.debug(`Instrumenting handler`);
-      const patchedHandler = lambdaInstrumentation.getPatchHandler(originalHandler) as any as Handler;
-      diag.debug(`Running CX handler and redirecting to ${process.env.CX_ORIGINAL_HANDLER}`)
-      const maybePromise = patchedHandler(event, context, callback);
-      if (typeof maybePromise?.then === 'function') {
-        maybePromise.then(
-          value => {
-            callback(null, value)
-          },
-          (err: Error | string) => {
-            callback(err, null)
-          }
-        );
+      try {
+        diag.debug(`Instrumenting handler`);
+        const patchedHandler = lambdaInstrumentation.getPatchHandler(originalHandler) as any as Handler;
+        diag.debug(`Running CX handler and redirecting to ${process.env.CX_ORIGINAL_HANDLER}`)
+        const maybePromise = patchedHandler(event, context, callback);
+        if (typeof maybePromise?.then === 'function') {
+          maybePromise.then(
+            value => {
+              context.callbackWaitsForEmptyEventLoop = false;
+              callback(null, value);
+            },
+            (err: Error | string | null | undefined) => {
+              if (err === undefined || err === null) {
+                context.callbackWaitsForEmptyEventLoop = false;
+                callback('handled', null);
+              } else {
+                context.callbackWaitsForEmptyEventLoop = false;
+                callback(err, null);
+              }
+            }
+          );
+        }
+      } catch (err: any) {
+        context.callbackWaitsForEmptyEventLoop = false;
+        callback(err, null);
       }
     },
     (err: Error | string) => {
+      context.callbackWaitsForEmptyEventLoop = false;
       callback(err, null)
     }
   );


### PR DESCRIPTION
Our handler is always callback based. We can't follow the handler type of the user's handler, becuase we don't know it (the only way we can learn it is by invoking the handler and seeing what it returns).

Unfortunately AWS's behaviour is different for Promise and callback based handlers. It waits for eventloop to be empty in case of callback based handlers (https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/blob/main/src/CallbackContext.js#L46). This means that wrapping a promise based handler in our handler implicitly enables that feature, leading to unindended behaviour. To solve this problem we disable the feature when the handler is promise based.