### PR TITLE
Let the default metrics exporter be enabled

### DIFF
--- a/python/sample-apps/otel/otel_sdk/otel-instrument
+++ b/python/sample-apps/otel/otel_sdk/otel-instrument
@@ -87,15 +87,10 @@ export PYTHONPATH="$LAMBDA_RUNTIME_DIR:$PYTHONPATH";
 # - We leave `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` to its default. This is
 #   `http://localhost:4318/v1/traces` because we are using the HTTP exporter
 
-# - Set the trace exporter
+# - Set the exporters
 
 if [ -z "${OTEL_EXPORTER_OTLP_PROTOCOL}" ]; then
     export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-fi
-# - Set the metrics exporter
-
-if [ -z ${OTEL_METRICS_EXPORTER} ]; then
-    export OTEL_METRICS_EXPORTER=none;
 fi
 
 # - Set the service name


### PR DESCRIPTION
This is a fix of https://github.com/coralogix/opentelemetry-lambda/pull/33