### PR TITLE
Introduce env variables for toggling instrumentations (like in Java)

### DIFF
--- a/nodejs/packages/cx-wrapper/common.ts
+++ b/nodejs/packages/cx-wrapper/common.ts
@@ -15,6 +15,19 @@ export const parseIntEnvvar = (envName: string): number | undefined => {
     if (isNaN(numericEnvvar)) return undefined;
     return numericEnvvar;
 };
+
+export const parseBooleanEnvvar = (envName: string): boolean | undefined => {
+  const envVar = process.env?.[envName];
+  if (envVar === undefined) return undefined;
+  const lowerCaseEnvVar = envVar.toLowerCase();
+  if (lowerCaseEnvVar === 'true' || lowerCaseEnvVar === 't') {
+    return true;
+  } else if (lowerCaseEnvVar === 'false' || lowerCaseEnvVar === 'f') {
+    return false 
+  } else {
+    return undefined;
+  }
+};
   
 const DEFAULT_OTEL_PAYLOAD_SIZE_LIMIT = 50 * 1024;
 export const OTEL_PAYLOAD_SIZE_LIMIT: number =

--- a/nodejs/packages/cx-wrapper/instrumentation-init.ts
+++ b/nodejs/packages/cx-wrapper/instrumentation-init.ts
@@ -1,8 +1,8 @@
 import { diag, Span } from '@opentelemetry/api';
 import { Instrumentation, registerInstrumentations } from '@opentelemetry/instrumentation';
-import { AwsInstrumentation, NormalizedResponse } from '@opentelemetry/instrumentation-aws-sdk';
+import { NormalizedResponse, AwsSdkRequestHookInformation, AwsSdkResponseHookInformation } from '@opentelemetry/instrumentation-aws-sdk';
 import { PgResponseHookInformation } from '@opentelemetry/instrumentation-pg';
-import { OTEL_PAYLOAD_SIZE_LIMIT, OtelAttributes } from './common';
+import { OTEL_PAYLOAD_SIZE_LIMIT, OtelAttributes, parseBooleanEnvvar } from './common';
 
 declare global {
   function configureInstrumentations(): Instrumentation[]
@@ -10,96 +10,79 @@ declare global {
 
 export function initializeInstrumentations(): any[] {
   diag.debug('Initializing OpenTelemetry instrumentations');
-  
-  const instrumentations = [
-    new AwsInstrumentation({
-      suppressInternalInstrumentation: true,
-      preRequestHook: (span: Span, { request }) => {
-        diag.debug(`preRequestHook for ${request.serviceName}.${request.commandName}`)
-
-        const data = JSON.stringify(request.commandInput);
-        if (data !== undefined) {
-          span.setAttribute(
-            OtelAttributes.RPC_REQUEST_PAYLOAD,
-            data.substring(0, OTEL_PAYLOAD_SIZE_LIMIT)
-          );
-        }
-      },
-      responseHook: (span, { response }) => {
-        diag.debug(`responseHook for ${response.request.serviceName}.${response.request.commandName}`)
-        if (response.request.serviceName === 'S3') {
-          if ('buckets' in response && Array.isArray(response.buckets)) {
-            setResponsePayloadAttribute(span, JSON.stringify(response.buckets.map(b => b.Name)))
-          } else if ('contents' in response && Array.isArray(response.contents)) {
-            setResponsePayloadAttribute(span, JSON.stringify(response.contents.map(b => b.Key)))
-          } else if ('data' in response && typeof response.data === 'object') {
-            // data is too large and it contains cycles
-          } else {
-            const payload = responseDataToString(response)
-            setResponsePayloadAttribute(span, payload)
-          }
-        } else {
-          const payload = responseDataToString(response)
-          setResponsePayloadAttribute(span, payload)
-        }
-      },
-    }),
-    ...(typeof configureInstrumentations === 'function' ? configureInstrumentations: defaultConfigureInstrumentations)()
-  ];
-
+  const instrumentations = (typeof configureInstrumentations === 'function' ? configureInstrumentations: defaultConfigureInstrumentations)();
   // Register instrumentations synchronously to ensure code is patched even before provider is ready.
-  registerInstrumentations({
-    instrumentations,
-  });
-
+  registerInstrumentations({instrumentations});
   return instrumentations;
 }
 
-function responseDataToString(response: NormalizedResponse): string {
-  return 'data' in response && typeof response.data === 'object'
-    ? JSON.stringify(response.data)
-    : response?.data?.toString();
-}
-
-function setResponsePayloadAttribute(span: Span, payload: string | undefined) {
-  if (payload !== undefined) {
-    span.setAttribute(
-      OtelAttributes.RPC_RESPONSE_PAYLOAD,
-      payload.substring(0, OTEL_PAYLOAD_SIZE_LIMIT)
-    );
-  }
-}
-
-function defaultConfigureInstrumentations() {
+function defaultConfigureInstrumentations(): Instrumentation[] {
   // Use require statements for instrumentation to avoid having to have transitive dependencies on all the typescript
   // definitions.
-  const { DnsInstrumentation } = require('@opentelemetry/instrumentation-dns');
-  const { ExpressInstrumentation } = require('@opentelemetry/instrumentation-express');
-  const { GraphQLInstrumentation } = require('@opentelemetry/instrumentation-graphql');
-  const { GrpcInstrumentation } = require('@opentelemetry/instrumentation-grpc');
-  const { HapiInstrumentation } = require('@opentelemetry/instrumentation-hapi');
-  const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http');
-  const { IORedisInstrumentation } = require('@opentelemetry/instrumentation-ioredis');
-  const { KoaInstrumentation } = require('@opentelemetry/instrumentation-koa');
-  const { MongoDBInstrumentation } = require('@opentelemetry/instrumentation-mongodb');
-  const { MySQLInstrumentation } = require('@opentelemetry/instrumentation-mysql');
-  const { NetInstrumentation } = require('@opentelemetry/instrumentation-net');
-  const { PgInstrumentation } = require('@opentelemetry/instrumentation-pg');
-  const { RedisInstrumentation } = require('@opentelemetry/instrumentation-redis');
-  return [ new DnsInstrumentation(),
-    new ExpressInstrumentation(),
-    new GraphQLInstrumentation(),
-    new GrpcInstrumentation(),
-    new HapiInstrumentation(),
-    new HttpInstrumentation(),
-    new IORedisInstrumentation(),
-    new KoaInstrumentation(),
-    new MongoDBInstrumentation({
+  const instrumentations: Instrumentation[] = [];
+  
+  const defaults = parseBooleanEnvvar("OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED") ?? true;
+
+  if (parseBooleanEnvvar("OTEL_INSTRUMENTATION_DNS_ENABLED") ?? defaults) {
+    const { DnsInstrumentation } = require('@opentelemetry/instrumentation-dns');
+    instrumentations.push(new DnsInstrumentation());
+  }
+
+  if (parseBooleanEnvvar("OTEL_INSTRUMENTATION_EXPRESS_ENABLED") ?? defaults) {
+    const { ExpressInstrumentation } = require('@opentelemetry/instrumentation-express');
+    instrumentations.push(new ExpressInstrumentation());
+  }
+
+  if (parseBooleanEnvvar("OTEL_INSTRUMENTATION_GRAPHQL_ENABLED") ?? defaults) {
+    const { GraphQLInstrumentation } = require('@opentelemetry/instrumentation-graphql');
+    instrumentations.push(new GraphQLInstrumentation());
+  }
+
+  if (parseBooleanEnvvar("OTEL_INSTRUMENTATION_GRPC_ENABLED") ?? defaults) {
+    const { GrpcInstrumentation } = require('@opentelemetry/instrumentation-grpc');
+    instrumentations.push(new GrpcInstrumentation());
+  }
+
+  if (parseBooleanEnvvar("OTEL_INSTRUMENTATION_HAPI_ENABLED") ?? defaults) {
+    const { HapiInstrumentation } = require('@opentelemetry/instrumentation-hapi');
+    instrumentations.push(new HapiInstrumentation());
+  }
+
+  if (parseBooleanEnvvar("OTEL_INSTRUMENTATION_HTTP_ENABLED") ?? defaults) {
+    const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http');
+    instrumentations.push(new HttpInstrumentation());
+  }
+
+  if (parseBooleanEnvvar("OTEL_INSTRUMENTATION_IOREDIS_ENABLED") ?? defaults) {
+    const { IORedisInstrumentation } = require('@opentelemetry/instrumentation-ioredis');
+    instrumentations.push(new IORedisInstrumentation());
+  }
+
+  if (parseBooleanEnvvar("OTEL_INSTRUMENTATION_KOA_ENABLED") ?? defaults) {
+    const { KoaInstrumentation } = require('@opentelemetry/instrumentation-koa');
+    instrumentations.push(new KoaInstrumentation());
+  }
+
+  if (parseBooleanEnvvar("OTEL_INSTRUMENTATION_MONGODB_ENABLED") ?? defaults) {
+    const { MongoDBInstrumentation } = require('@opentelemetry/instrumentation-mongodb');
+    instrumentations.push(new MongoDBInstrumentation({
       enhancedDatabaseReporting: process.env.MONGO_ENHANCED_REPORTING === 'true'
-    }),
-    new MySQLInstrumentation(),
-    new NetInstrumentation(),
-    new PgInstrumentation({
+    }));
+  }
+
+  if (parseBooleanEnvvar("OTEL_INSTRUMENTATION_MYSQL_ENABLED") ?? defaults) {
+    const { MySQLInstrumentation } = require('@opentelemetry/instrumentation-mysql');
+    instrumentations.push(new MySQLInstrumentation());
+  }
+
+  if (parseBooleanEnvvar("OTEL_INSTRUMENTATION_NET_ENABLED") ?? defaults) {
+    const { NetInstrumentation } = require('@opentelemetry/instrumentation-net');
+    instrumentations.push(new NetInstrumentation());
+  }
+
+  if (parseBooleanEnvvar("OTEL_INSTRUMENTATION_PG_ENABLED") ?? defaults) {
+    const { PgInstrumentation } = require('@opentelemetry/instrumentation-pg');
+    instrumentations.push(new PgInstrumentation({
       responseHook: (span: Span, responseInfo: PgResponseHookInformation) => {
         try {
           if (responseInfo?.data?.rows) {
@@ -113,8 +96,12 @@ function defaultConfigureInstrumentations() {
           return;
         }
       },
-    }),
-    new RedisInstrumentation({
+    }));
+  }
+
+  if (parseBooleanEnvvar("OTEL_INSTRUMENTATION_REDIS_ENABLED") ?? defaults) {
+    const { RedisInstrumentation } = require('@opentelemetry/instrumentation-redis');
+    instrumentations.push(new RedisInstrumentation({
       responseHook: (
         span: Span,
         cmdName: string,
@@ -132,6 +119,59 @@ function defaultConfigureInstrumentations() {
           );
         }
       },
-    }),
-  ]
+    }));
+  }
+
+  if (parseBooleanEnvvar("OTEL_INSTRUMENTATION_AWS_SDK_ENABLED") ?? defaults) {
+    const { AwsInstrumentation } = require('@opentelemetry/instrumentation-aws-sdk');
+    instrumentations.push(new AwsInstrumentation({
+      suppressInternalInstrumentation: true,
+      preRequestHook: (span: Span, { request }: AwsSdkRequestHookInformation) => {
+        diag.debug(`preRequestHook for ${request.serviceName}.${request.commandName}`)
+
+        const data = JSON.stringify(request.commandInput);
+        if (data !== undefined) {
+          span.setAttribute(
+            OtelAttributes.RPC_REQUEST_PAYLOAD,
+            data.substring(0, OTEL_PAYLOAD_SIZE_LIMIT)
+          );
+        }
+      },
+      responseHook: (span: Span, { response } : AwsSdkResponseHookInformation) => {
+        diag.debug(`responseHook for ${response.request.serviceName}.${response.request.commandName}`)
+        if (response.request.serviceName === 'S3') {
+          if ('buckets' in response && Array.isArray(response.buckets)) {
+            setResponsePayloadAttribute(span, JSON.stringify(response.buckets.map(b => b.Name)))
+          } else if ('contents' in response && Array.isArray(response.contents)) {
+            setResponsePayloadAttribute(span, JSON.stringify(response.contents.map(b => b.Key)))
+          } else if ('data' in response && typeof response.data === 'object') {
+            // data is too large and it contains cycles
+          } else {
+            const payload = responseDataToString(response)
+            setResponsePayloadAttribute(span, payload)
+          }
+        } else {
+          const payload = responseDataToString(response)
+          setResponsePayloadAttribute(span, payload)
+        }
+      },
+    }))
+  }
+
+  return instrumentations;  
+}
+
+function responseDataToString(response: NormalizedResponse): string {
+  return 'data' in response && typeof response.data === 'object'
+    ? JSON.stringify(response.data)
+    : response?.data?.toString();
+}
+
+function setResponsePayloadAttribute(span: Span, payload: string | undefined) {
+  if (payload !== undefined) {
+    span.setAttribute(
+      OtelAttributes.RPC_RESPONSE_PAYLOAD,
+      payload.substring(0, OTEL_PAYLOAD_SIZE_LIMIT)
+    );
+  }
 }

--- a/nodejs/packages/cx-wrapper/package-lock.json
+++ b/nodejs/packages/cx-wrapper/package-lock.json
@@ -287,7 +287,7 @@
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
       "version": "0.39.0",
       "resolved": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-lambda/opentelemetry-instrumentation-aws-lambda-0.39.0.tgz",
-      "integrity": "sha512-jQxaSeuBI05oWHMGId/4ieS3cdGRiGKaXTVdFlpJnVdpzfPXXj6FfDXPpUDO6dvHPmYmSNe30VhnxAcCX1JwfA==",
+      "integrity": "sha512-XyZgB51I14jtz7GbQuG1PZfQ8NMRmdmzMovaHv7jAHQxpsrkAx4V/R9NdAw2UyeQhU/6Hj+nXvo57rA3taPS3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.49.1",
@@ -1726,7 +1726,7 @@
     },
     "@opentelemetry/instrumentation-aws-lambda": {
       "version": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-lambda/opentelemetry-instrumentation-aws-lambda-0.39.0.tgz",
-      "integrity": "sha512-jQxaSeuBI05oWHMGId/4ieS3cdGRiGKaXTVdFlpJnVdpzfPXXj6FfDXPpUDO6dvHPmYmSNe30VhnxAcCX1JwfA==",
+      "integrity": "sha512-XyZgB51I14jtz7GbQuG1PZfQ8NMRmdmzMovaHv7jAHQxpsrkAx4V/R9NdAw2UyeQhU/6Hj+nXvo57rA3taPS3A==",
       "requires": {
         "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/propagator-aws-xray": "^1.3.1",


### PR DESCRIPTION
This PR introduces feature flags (as env variables) the let the user disable the default set of instrumentations, and/or toggle instrumentations one by one. This is analogical to what Java OTEL offers (you can see example of us using the Java variables here: https://github.com/coralogix/opentelemetry-lambda/blob/coralogix-java-autoinstrumentation/java/layer-javaagent/scripts/otel-handler#L14-L31)