### PR TITLE
Remove handling of promises + fix issues connecting unrelated traces

### DIFF
--- a/nodejs/packages/cx-wrapper/index.ts
+++ b/nodejs/packages/cx-wrapper/index.ts
@@ -40,24 +40,7 @@ export const handler = (event: any, context: Context, callback: Callback) => {
         diag.debug(`Instrumenting handler`);
         const patchedHandler = lambdaInstrumentation.getPatchHandler(originalHandler) as any as Handler;
         diag.debug(`Running CX handler and redirecting to ${process.env.CX_ORIGINAL_HANDLER}`)
-        const maybePromise = patchedHandler(event, context, callback);
-        if (typeof maybePromise?.then === 'function') {
-          maybePromise.then(
-            value => {
-              context.callbackWaitsForEmptyEventLoop = false;
-              callback(null, value);
-            },
-            (err: Error | string | null | undefined) => {
-              if (err === undefined || err === null) {
-                context.callbackWaitsForEmptyEventLoop = false;
-                callback('handled', null);
-              } else {
-                context.callbackWaitsForEmptyEventLoop = false;
-                callback(err, null);
-              }
-            }
-          );
-        }
+        patchedHandler(event, context, callback);
       } catch (err: any) {
         context.callbackWaitsForEmptyEventLoop = false;
         callback(err, null);

--- a/nodejs/packages/cx-wrapper/lambda-instrumentation-init.ts
+++ b/nodejs/packages/cx-wrapper/lambda-instrumentation-init.ts
@@ -1,10 +1,10 @@
 import {
-  context as otelContext,
   defaultTextMapGetter,
   Context as OtelContext,
   propagation,
   trace,
-  diag
+  diag,
+  ROOT_CONTEXT
 } from '@opentelemetry/api';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { AwsLambdaInstrumentation, AwsLambdaInstrumentationConfig } from '@opentelemetry/instrumentation-aws-lambda';
@@ -35,7 +35,7 @@ export function makeLambdaInstrumentation(): AwsLambdaInstrumentation {
       // try to extract propagation from http headers first
       const httpHeaders = event?.headers || {};
       const extractedHttpContext: OtelContext = propagation.extract(
-        otelContext.active(),
+        ROOT_CONTEXT,
         httpHeaders,
         defaultTextMapGetter
       );
@@ -48,7 +48,7 @@ export function makeLambdaInstrumentation(): AwsLambdaInstrumentation {
         try {
           const extractedClientContextOtelContext: OtelContext =
             propagation.extract(
-              otelContext.active(),
+              ROOT_CONTEXT,
               context.clientContext.Custom,
               defaultTextMapGetter
             );
@@ -65,7 +65,7 @@ export function makeLambdaInstrumentation(): AwsLambdaInstrumentation {
         try {
           const extractedClientContextOtelContext: OtelContext =
             propagation.extract(
-              otelContext.active(),
+              ROOT_CONTEXT,
               (context.clientContext as any).custom,
               defaultTextMapGetter
             );
@@ -79,7 +79,7 @@ export function makeLambdaInstrumentation(): AwsLambdaInstrumentation {
           );
         }
       }
-      return otelContext.active();
+      return ROOT_CONTEXT;
     },
     payloadSizeLimit: OTEL_PAYLOAD_SIZE_LIMIT,
   };


### PR DESCRIPTION
We don't need to handle promises here because https://github.com/coralogix/opentelemetry-js-contrib/pull/19 will convert promise based handlers to callback based.

The change to use ROOT_CONTEXT basically means that when we don't receive any trace information in the request, then we start a new trace. The previous code would in some edge cases reuse leftover trace context from previous invocation which doesn't make sense.