### PR TITLE
python: pin setuptools dependency

### DIFF
--- a/python/sample-apps/otel/otel_sdk/requirements.txt
+++ b/python/sample-apps/otel/otel_sdk/requirements.txt
@@ -2,4 +2,5 @@ opentelemetry-exporter-otlp-proto-http==1.24.0
 opentelemetry-distro==0.45b0
 file:opentelemetry_instrumentation_aws_lambda-0.45b0-py3-none-any.whl
 file:opentelemetry_instrumentation_botocore-0.45b0-py3-none-any.whl
+setuptools==75.3.0
 #file:opentelemetry_instrumentation_psycopg2-0.39b0.dev0-py3-none-any.whl


### PR DESCRIPTION
FIX: ES-416

Looks like setuptools 75.4 has removed support for Python 3.8