### PR TITLE
Update runner to fix publish-python action

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   package:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.ref == 'refs/heads/coralogix-python-autoinstrumentation' || inputs.environment == 'test' }}
     environment: ${{ inputs.environment }}
     env:
@@ -61,7 +61,7 @@ jobs:
         retention-days: 1
 
   publish-layer:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.ref == 'refs/heads/coralogix-python-autoinstrumentation' || inputs.environment == 'test' }}
     needs: [package]
     environment: ${{ inputs.environment }}


### PR DESCRIPTION
There is a problem with `ubuntu-22.04` https://github.com/actions/runner-images/issues/11611

```sh
2025-03-17T09:05:46.4347311Z   × Preparing metadata (pyproject.toml) did not run successfully.
2025-03-17T09:05:46.4348027Z   │ exit code: 1
2025-03-17T09:05:46.4348504Z   ╰─> [14 lines of output]
2025-03-17T09:05:46.4349014Z       Traceback (most recent call last):
2025-03-17T09:05:46.4349971Z         File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
2025-03-17T09:05:46.4350889Z           main()
2025-03-17T09:05:46.4351727Z         File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
2025-03-17T09:05:46.4352726Z           json_out['return_val'] = hook(**hook_input['kwargs'])
2025-03-17T09:05:46.4353944Z         File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 164, in prepare_metadata_for_build_wheel
2025-03-17T09:05:46.4355089Z           return hook(metadata_directory, config_settings)
2025-03-17T09:05:46.4356592Z         File "/tmp/pip-build-env-m6ejoccb/overlay/local/lib/python3.10/dist-packages/hatchling/build.py", line 117, in prepare_metadata_for_build_wheel
2025-03-17T09:05:46.4357963Z           f.write(builder.config.core_metadata_constructor(builder.metadata))
2025-03-17T09:05:46.4359381Z         File "/tmp/pip-build-env-m6ejoccb/overlay/local/lib/python3.10/dist-packages/hatchling/metadata/spec.py", line 546, in construct_metadata_file_2_4
2025-03-17T09:05:46.4360583Z           if metadata.core.license:
2025-03-17T09:05:46.4362034Z         File "/tmp/pip-build-env-m6ejoccb/overlay/local/lib/python3.10/dist-packages/hatchling/metadata/core.py", line 677, in license
2025-03-17T09:05:46.4363269Z           from packaging.licenses import canonicalize_license_expression
2025-03-17T09:05:46.4364087Z       ModuleNotFoundError: No module named 'packaging.licenses'
2025-03-17T09:05:46.4364720Z       [end of output]
2025-03-17T09:05:46.4365112Z   
2025-03-17T09:05:46.4365891Z   note: This error originates from a subprocess, and is likely not a problem with pip.
2025-03-17T09:05:46.4366633Z error: metadata-generation-failed
2025-03-17T09:05:46.4366977Z 
2025-03-17T09:05:46.4367422Z × Encountered error while generating package metadata.
2025-03-17T09:05:46.4368390Z ╰─> See above for output.
```
https://productionresultssa19.blob.core.windows.net/actions-results/2961cc28-e2b5-4839-ae6e-8302e55c3888/workflow-job-run-1d2f55de-c984-5e06-0d18-75388f298a89/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-03-17T09%3A16%3A59Z&sig=c02UG6%2F0dAfnHbJyIiBZGAdnZ3GZ7TwBHhzjUjxUn0o%3D&ske=2025-03-17T17%3A12%3A10Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-03-17T05%3A12%3A10Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-03-17T09%3A06%3A54Z&sv=2025-01-05