### PR TITLE
Fix nodejs wrapper package lock

### DIFF
--- a/nodejs/packages/cx-wrapper/package-lock.json
+++ b/nodejs/packages/cx-wrapper/package-lock.json
@@ -183,9 +183,9 @@
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
       "version": "0.50.3",
       "resolved": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-lambda/opentelemetry-instrumentation-aws-lambda-0.50.3.tgz",
-      "integrity": "sha512-IQnmzK3q4rbMqkK0LqFspjS8NWVM3qZZnuW1QmibtBHahH3c5IT472+mj9qUivw1z0il8MjjXpwIcQ1+HlCmMQ==",
+      "integrity": "sha512-nIReEF/MxAeuaJbgUL5jvLb5ftWpOdYpCReU8h/4akfO0dT8Qmstm7ZE9xIhCf3RG/i1s1yYS8nlg6/Q3bwtNA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/instrumentation": "^0.57.2",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/aws-lambda": "8.10.147"
       },

--- a/nodejs/packages/layer/package-lock.json
+++ b/nodejs/packages/layer/package-lock.json
@@ -185,9 +185,9 @@
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
       "version": "0.50.3",
       "resolved": "file:../../../../opentelemetry-js-contrib-cx/plugins/node/opentelemetry-instrumentation-aws-lambda/opentelemetry-instrumentation-aws-lambda-0.50.3.tgz",
-      "integrity": "sha512-IQnmzK3q4rbMqkK0LqFspjS8NWVM3qZZnuW1QmibtBHahH3c5IT472+mj9qUivw1z0il8MjjXpwIcQ1+HlCmMQ==",
+      "integrity": "sha512-nIReEF/MxAeuaJbgUL5jvLb5ftWpOdYpCReU8h/4akfO0dT8Qmstm7ZE9xIhCf3RG/i1s1yYS8nlg6/Q3bwtNA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/instrumentation": "^0.57.2",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/aws-lambda": "8.10.147"
       },


### PR DESCRIPTION
Fixes ES-492.

Required after https://github.com/coralogix/opentelemetry-js-contrib/pull/25