### PR TITLE
[CDS-2808] Fix: Pin setuptools to resolve CVE-2026-23949

### DIFF
--- a/python/src/otel/otel_sdk/requirements.txt
+++ b/python/src/otel/otel_sdk/requirements.txt
@@ -1,3 +1,4 @@
 opentelemetry-exporter-otlp-proto-http==1.17.0
 opentelemetry-distro==0.38b0
 opentelemetry-instrumentation-aws-lambda==0.38b0
+setuptools>=75.8.0


### PR DESCRIPTION
## Summary
- Pins `setuptools>=75.8.0` in the Python Lambda layer requirements to resolve **CVE-2026-23949**
- The vulnerability is a Zip Slip path traversal in `jaraco.context` (versions 5.2.0 to < 6.1.0), which is vendored inside `setuptools`
- The current layer (`coralogix-python-wrapper-and-exporter-x86_64:30`) bundles `jaraco.context-5.3.0` via setuptools, which is affected

## Details
A customer reported that the Coralogix Python Lambda layer contains a vulnerable version of `jaraco.context` (5.3.0) bundled within `setuptools`. The `jaraco.context.tarball()` function has a Zip Slip path traversal vulnerability that could allow attackers to extract files outside the intended directory.

The fix pins `setuptools>=75.8.0` which vendors `jaraco.context >= 6.1.0` (the patched version).

## Test plan
- [ ] Build the Python Lambda layer using the Dockerfile and verify the new layer contains `jaraco.context >= 6.1.0`
- [ ] Verify no runtime regressions by deploying to a test Lambda function
- [ ] Confirm the vulnerability is resolved by inspecting the built layer:
  ```
  find layer_contents -path "*jaraco*" -name "METADATA" -exec grep -l "jaraco.context" {} \;
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)