### PR TITLE
Remove setuptools as a dependency

### DIFF
--- a/python/sample-apps/otel/otel_sdk/requirements.txt
+++ b/python/sample-apps/otel/otel_sdk/requirements.txt
@@ -4,4 +4,3 @@ opentelemetry-sdk==1.39.0
 opentelemetry-distro==0.60b0
 file:opentelemetry_instrumentation_aws_lambda-0.60b0-py3-none-any.whl
 file:opentelemetry_instrumentation_botocore-0.60b0-py3-none-any.whl
-setuptools==80.8.0


### PR DESCRIPTION
The dependency is not needed. It is not even listed in our documentation.

Tested E2E. Since we provide `pip.conf` file, if users need to install anything, we are covered against possible issues trying to install newer versions of the OTEL libraries.